### PR TITLE
Fix code scanning alert no. 7: Partial server-side request forgery

### DIFF
--- a/superagi/controllers/twitter_oauth.py
+++ b/superagi/controllers/twitter_oauth.py
@@ -17,7 +17,9 @@ from superagi.models.toolkit import Toolkit
 router = APIRouter()
 
 @router.get('/oauth-tokens')
-async def twitter_oauth(oauth_token: str = Query(...),oauth_verifier: str = Query(...), Authorize: AuthJWT = Depends()):
+async def twitter_oauth(oauth_token: str = Query(...), oauth_verifier: str = Query(...), Authorize: AuthJWT = Depends()):
+    if not (oauth_token.isalnum() and oauth_verifier.isalnum()):
+        return {"error": "Invalid oauth_token or oauth_verifier"}
     token_uri = f'https://api.twitter.com/oauth/access_token?oauth_verifier={oauth_verifier}&oauth_token={oauth_token}'
     conn = http_client.HTTPSConnection("api.twitter.com")
     conn.request("POST", token_uri, "")


### PR DESCRIPTION
Fixes [https://github.com/devops-testbed/SuperAGI/security/code-scanning/7](https://github.com/devops-testbed/SuperAGI/security/code-scanning/7)

To fix the problem, we need to validate the user-provided input (`oauth_token` and `oauth_verifier`) before using them to construct the `token_uri`. One way to do this is to ensure that these values are alphanumeric, which would prevent the inclusion of special characters that could be used to manipulate the URL.

We will add validation checks for `oauth_token` and `oauth_verifier` to ensure they are alphanumeric. If they are not, we will return an appropriate error response.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
